### PR TITLE
Fix type errors found by ty 0.0.1a34

### DIFF
--- a/feed_baby/app.py
+++ b/feed_baby/app.py
@@ -196,7 +196,7 @@ def bootstrap_server(app: FastAPI, db_path: str, secure_cookies: bool = False) -
             key="session_id",
             value=session_id,
             httponly=True,
-            samesite="Lax",
+            samesite="lax",
             secure=request.app.state.secure_cookies,
         )
         return response
@@ -248,7 +248,7 @@ def bootstrap_server(app: FastAPI, db_path: str, secure_cookies: bool = False) -
             key="session_id",
             value=session_id,
             httponly=True,
-            samesite="Lax",
+            samesite="lax",
             secure=request.app.state.secure_cookies,
         )
         return response
@@ -261,7 +261,7 @@ def bootstrap_server(app: FastAPI, db_path: str, secure_cookies: bool = False) -
 
         response = RedirectResponse(url="/", status_code=303)
         response.delete_cookie(
-            key="session_id", samesite="Lax", secure=request.app.state.secure_cookies
+            key="session_id", samesite="lax", secure=request.app.state.secure_cookies
         )
         return response
 

--- a/tests/test_feed.py
+++ b/tests/test_feed.py
@@ -71,6 +71,7 @@ def test_feed_datetime_parsing():
         timezone="America/Los_Angeles",
         user_id=1,
     )
+    assert feed.datetime.timezone is not None
     assert feed.datetime.timezone.name == "America/Los_Angeles"
     assert feed.datetime.hour == 9
     assert feed.datetime.minute == 15
@@ -236,5 +237,6 @@ def test_feed_count(tmp_path):
 
     # Delete a feed and verify count decreases
     feeds = Feed.get_all(db_path)
+    assert feeds[0].id is not None
     Feed.delete(feeds[0].id, db_path)
     assert Feed.count(db_path) == 9


### PR DESCRIPTION
## Summary
Resolves all type diagnostics found by the updated ty type checker (v0.0.1a34).

## Changes
- Fix samesite parameter case in cookie operations (3 instances in `feed_baby/app.py:199, 251, 264`)
  - Changed `samesite="Lax"` to `samesite="lax"` to match Starlette's type signature
- Add type assertion for timezone in `tests/test_feed.py:74`
  - Asserts timezone is not None before accessing `.name` attribute
- Add type assertion for feed id in `tests/test_feed.py:240`
  - Asserts id is not None before passing to `Feed.delete()`

## Test plan
- [x] All 61 tests pass
- [x] `uv run ty check` reports no errors (down from 5 diagnostics)
- [x] `uv run ruff check` passes
- [x] Pre-commit hooks (lefthook) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)